### PR TITLE
mark processor as noincorporate

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -1118,7 +1118,7 @@ system/library/gfortran-9-runtime@9.4.0,5.11-2020.0.1.1
 system/library/gobjc-9-runtime@9.4.0,5.11-2020.0.1.1
 system/library/libvirt@0.5.11,5.11-2015.0.2.0
 system/library/math/header-math@0.5.11,5.11-2022.0.1.0 system/library/math
-system/library/processor@0.5.11,5.11-2022.0.1.0
+system/library/processor@0.5.11,5.11-2022.0.1.0 noincorporate
 system/library/python/libbe-27@0.5.11,5.11-2022.0.1.0 noincorporate
 system/library/python/libbe-35@0.5.11,5.11-2022.0.1.0
 system/library/python/solaris-27@0.5.11,5.11-2022.0.1.0 noincorporate


### PR DESCRIPTION
I'm not really certain if this is the proper fix, but I am not able to update a freshly installed hipster.  Due to the following errors.
```
# pkg update -v
Creating Plan (Running solver): \
pkg update: No solution was found to satisfy constraints
No solution found to update to latest available versions.
This may indicate an overly constrained set of packages are installed.
 
latest incorporations:
 
  pkg://openindiana.org/consolidation/install/install-incorporation@0.5.11,5.11-2022.0.0.1061:20220917T092526Z
  pkg://openindiana.org/consolidation/osnet/osnet-incorporation@0.5.11,5.11-2022.0.0.21287:20221010T010743Z
  pkg://openindiana.org/consolidation/userland/userland-incorporation@0.5.11,5.11-2022.0.0.16880:20221009T143209Z
 
The following indicates why the system cannot update to the latest version:
 
    Reject:  pkg://openindiana.org/consolidation/osnet/osnet-incorporation@0.5.11-2022.0.0.21286:20221009T011330Z
    Reason:  No version for 'incorporate' dependency on system/library/processor@0.5.11-2022.0.0.21286 can be found
    Reject:  pkg://openindiana.org/consolidation/osnet/osnet-incorporation@0.5.11-2022.0.0.21286:20221008T074057Z
    Reason:  No version for 'incorporate' dependency on system/library/processor@0.5.11-2022.0.0.21286 can be found
    Reject:  pkg://openindiana.org/consolidation/osnet/osnet-incorporation@0.5.11-2022.0.0.21287:20221010T010743Z
    Reason:  No version for 'incorporate' dependency on system/library/processor@0.5.11-2022.0.0.21287 can be found
    Reject:  pkg://openindiana.org/consolidation/osnet/osnet-incorporation@0.5.11-2022.0.0.21284:20221007T010842Z
    Reason:  No version for 'incorporate' dependency on system/library/processor@0.5.11-2022.0.0.21284 can be found
```